### PR TITLE
Support to set `dict key size threshold`

### DIFF
--- a/src/_pyorc/Writer.cpp
+++ b/src/_pyorc/Writer.cpp
@@ -95,7 +95,8 @@ Writer::Writer(py::object fileo,
                double bloom_filter_fpp,
                py::object tzone,
                unsigned int struct_repr,
-               py::object conv)
+               py::object conv,
+               double dict_key_size_threshold)
 {
     currentRow = 0;
     batchItem = 0;
@@ -119,6 +120,7 @@ Writer::Writer(py::object fileo,
     options = options.setRowIndexStride(row_index_stride);
     options = options.setColumnsUseBloomFilter(bloom_filter_columns);
     options = options.setBloomFilterFPP(bloom_filter_fpp);
+    options = options.setDictionaryKeySizeThreshold(dict_key_size_threshold);
     if (!tzone.is_none()) {
         std::string tzKey = py::cast<std::string>(tzone.attr("key"));
         options = options.setTimezoneName(tzKey);

--- a/src/_pyorc/Writer.h
+++ b/src/_pyorc/Writer.h
@@ -35,7 +35,8 @@ class Writer
            double = 0.05,
            py::object = py::none(),
            unsigned int = 0,
-           py::object = py::none());
+           py::object = py::none(),
+           double = 0.0);
     void addUserMetadata(py::str, py::bytes);
     void write(py::object);
     void close();

--- a/src/_pyorc/_pyorc.cpp
+++ b/src/_pyorc/_pyorc.cpp
@@ -94,7 +94,8 @@ PYBIND11_MODULE(_pyorc, m)
                     double,
                     py::object,
                     unsigned int,
-                    py::object>(),
+                    py::object,
+                    double>(),
            py::arg("fileo"),
            py::arg("schema"),
            py::arg_v("batch_size", 1024, "1024"),
@@ -107,7 +108,8 @@ PYBIND11_MODULE(_pyorc, m)
            py::arg_v("bloom_filter_fpp", 0.05, "0.05"),
            py::arg_v("timezone", py::none(), "None"),
            py::arg_v("struct_repr", 0, "StructRepr.TUPLE"),
-           py::arg_v("conv", py::none(), "None"))
+           py::arg_v("conv", py::none(), "None"),
+           py::arg_v("dict_key_size_threshold", 0.0, "0.0"))
       .def("_add_user_metadata", &Writer::addUserMetadata)
       .def("write", &Writer::write)
       .def("close", &Writer::close)

--- a/src/pyorc/writer.py
+++ b/src/pyorc/writer.py
@@ -28,6 +28,7 @@ class Writer(writer):
         timezone: zoneinfo.ZoneInfo = zoneinfo.ZoneInfo("UTC"),
         struct_repr: StructRepr = StructRepr.TUPLE,
         converters: Optional[dict] = None,
+        dict_key_size_threshold = 0.0,
     ) -> None:
         if isinstance(schema, str):
             schema = TypeDescription.from_string(schema)
@@ -69,6 +70,7 @@ class Writer(writer):
             timezone,
             struct_repr,
             conv,
+            dict_key_size_threshold
         )
 
     def __enter__(self):


### PR DESCRIPTION
Sometimes we want to create a ORC file with dictionary encoding, and we can force to use dictionary encoding by setting `dict_key_size_threshold=1.0f`